### PR TITLE
Ditch base64url package dependency

### DIFF
--- a/ECToken.js
+++ b/ECToken.js
@@ -1,5 +1,4 @@
 const crypto = require('crypto')
-const base64url = require('base64url')
 
 const iv_size_bytes = 12
 
@@ -107,7 +106,7 @@ async function encrypt(key, token, verbose = false) {
     console.log('+---------------------------------------------------------------------------------------------------')
   }
 
-  return base64url.encode(iv_ciphertext)
+  return Buffer.from(iv_ciphertext).toString('base64url')
 }
 
 /**
@@ -121,7 +120,7 @@ async function decrypt(key, token, verbose = false) {
   const key_encoded = new TextEncoder().encode(key)
   const key_digest = await crypto.subtle.digest('SHA-256', key_encoded)
 
-  const decoded_token = base64url.toBuffer(token)
+  const decoded_token = Buffer.from(token, 'base64url')
 
   // First n bytes (iv_size_bytes) is the iv.
   const iv = decoded_token.subarray(0, iv_size_bytes)

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,7 @@
     "": {
       "name": "@edgio/ectoken",
       "version": "1.0.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64url": "^3.0.1"
-      }
-    },
-    "node_modules/base64url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgio/ectoken",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "JS implementation of Edgio token (ectoken)",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
   ],
   "author": "Tom Mount <tmount@edg.io>",
   "license": "Apache-2.0",
-  "dependencies": {
-    "base64url": "^3.0.1"
-  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
As described by Issue #3 base64url has security vulnerabilities and is no longer needed.
This PR replaces the package for the Buffer API