### PR TITLE
Ditch base64url package

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -1,5 +1,4 @@
 const crypto = require('crypto')
-const base64url = require('base64url')
 
 const iv_size_bytes = 12
 
@@ -45,7 +44,7 @@ async function encrypt(key, token, verbose = false) {
     console.log('+---------------------------------------------------------------------------------------------------')
   }
 
-  return base64url.encode(iv_ciphertext)
+  return Buffer.from(iv_ciphertext).toString('base64url')
 }
 
 /**
@@ -59,7 +58,7 @@ async function decrypt(key, token, verbose = false) {
   const key_encoded = new TextEncoder().encode(key)
   const key_digest = await crypto.subtle.digest('SHA-256', key_encoded)
 
-  const decoded_token = base64url.toBuffer(token)
+  const decoded_token = Buffer.from(token, 'base64url')
 
   // First n bytes (iv_size_bytes) is the iv.
   const iv = decoded_token.subarray(0, iv_size_bytes)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "@edgio/ectoken",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@edgio/ectoken",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "Apache-2.0",
-      "dependencies": {
-        "base64url": "^3.0.1"
-      },
       "devDependencies": {
         "chai": "^4",
         "chai-as-promised": "^7.1.2",
@@ -86,14 +83,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
-    },
-    "node_modules/base64url": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
-      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@edgio/ectoken",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@edgio/ectoken",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
     "node": ">= 15.0.0"
   },
   "homepage": "https://github.com/Edgio/js-ectoken#readme",
-  "dependencies": {
-    "base64url": "^3.0.1"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgio/ectoken",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "JS implementation of Edgio token (ectoken)",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
As described by #3 

PR #4   was ditched due to changes in the repo that includes unit testing.

All tests are passing.