### PR TITLE
update crypto helpers to work in browser-compatible ways

### DIFF
--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -1,4 +1,11 @@
-const crypto = require('crypto')
+let crypto
+if (typeof window !== 'undefined' && window.crypto) {
+  // Use the Web API if it's available.
+  crypto = window.crypto
+} else {
+  // Otherwise use Node.js's version
+  crypto = require('crypto')
+}
 
 const iv_size_bytes = 12
 
@@ -44,7 +51,13 @@ async function encrypt(key, token, verbose = false) {
     console.log('+---------------------------------------------------------------------------------------------------')
   }
 
-  return Buffer.from(iv_ciphertext).toString('base64url')
+  // Convert non-url-safe base64 string to url-safe version in a way that browsers
+  // won't complain about.
+  const toReturn = Buffer.from(iv_ciphertext).toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '')
+  return toReturn
 }
 
 /**
@@ -58,7 +71,9 @@ async function decrypt(key, token, verbose = false) {
   const key_encoded = new TextEncoder().encode(key)
   const key_digest = await crypto.subtle.digest('SHA-256', key_encoded)
 
-  const decoded_token = Buffer.from(token, 'base64url')
+  // Convert url-safe base64 string to its standard base64 counterpart in a way
+  // that browsers won't complain about.
+  const decoded_token = Buffer.from(token.replace(/-/g, '+').replace(/_/g, '/'), 'base64')
 
   // First n bytes (iv_size_bytes) is the iv.
   const iv = decoded_token.subarray(0, iv_size_bytes)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edgio/ectoken",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "JS implementation of Edgio token (ectoken)",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
* conditionally import the correct `crypto` module based on the presence of `window`
* remove use of `base64url` from all Buffer operations and convert the string either to or from base64url-style encoding before using fully-supported `base64` encoding